### PR TITLE
Create a basic cmake build system [ESD-1246] [ESD-1247]

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,6 @@
+cmake_minimum_required(VERSION 3.0)
+
+project(fast-csv CXX)
+
+add_library(fast-csv INTERFACE)
+target_include_directories(fast-csv INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>)


### PR DESCRIPTION
Integrates with https://github.com/swift-nav/cmake/pull/2

Part of the epic to do with how we find and include project dependencies.

This PR create a simple cmake build system for this header only library. The new CMakeLists.txt exports an interface library target so that superprojects do not have to pull include paths out of the submodule directly.