### PR TITLE
Use optionals.

### DIFF
--- a/csv.h
+++ b/csv.h
@@ -929,7 +929,7 @@ void parse_signed_integer(const char *col, optional<T> &x) {
           overflow_policy::on_underflow(*x);
           return;
         }
-        *x = (x ? 10 * *x : 0) - y;
+        x = (x ? 10 * *x : 0) - y;
       } else
         throw error::no_digit();
       ++col;


### PR DESCRIPTION
@jbangelo @lkloh @woodfell looking for some ideas here. The fundamental problem I've identified is that if a csv file has nothing in a field, this reader will assign a zero to it. We don't want this to occur, because a zero can mean all sorts of things (if it's a standard deviation or a variance, it's really good; if it's an enum, it could be anything) and typically whatever it does mean is not what an empty field means.

I've taken a half-hearted stab at introducing `optional`s to try to deal with this (so the caller passes in the appropriate `optional` and knows from the return value if the field was empty). If worst comes to worst, we could use some sentinel value to indicate an empty field, but it's a bit dirty and there's always the off chance that we actually do read in the sentinel value, meaning something else. I kind of wonder if we may have to go down that road (or do a big refactor), but if any of you have a better idea, please let me know.