### PR TITLE
Allow empty strings, because returning an empty string tells the call…

### DIFF
--- a/csv.h
+++ b/csv.h
@@ -877,7 +877,7 @@ bool parse(char *col, char &x) {
 template <class overflow_policy>
 bool parse(char *col, std::string &x) {
   x = col;
-  return x.size() > 0;
+  return true;
 }
 
 template <class overflow_policy>


### PR DESCRIPTION
…er that the field was empty.