### PR TITLE
Ignore `-Wstringop-truncation` warnings

### DIFF
--- a/csv.h
+++ b/csv.h
@@ -49,6 +49,11 @@
 #include <istream>
 #include <memory>
 
+#pragma GCC diagnostic push
+#if __GNUC__ && __GNUC__ >= 8
+#pragma GCC diagnostic ignored "-Wstringop-truncation"
+#endif
+
 namespace io {
 ////////////////////////////////////////////////////////////////////////////
 //                                 LineReader                             //
@@ -1232,4 +1237,5 @@ class CSVReader {
   }
 };
 }  // namespace io
+#pragma GCC diagnostic pop
 #endif


### PR DESCRIPTION
`-Wstringop-truncation` warning is giving lot of trouble when building on GCC-8 and above. This patch will disable those warnings 

Upstream also has a similar kind of [hack](https://github.com/ben-strasser/fast-cpp-csv-parser/commit/1165be530d19ed730228dd122f2df0896be8f64e)